### PR TITLE
Add 'traffic_api' in settings.py

### DIFF
--- a/daelibs_interview/settings.py
+++ b/daelibs_interview/settings.py
@@ -38,6 +38,8 @@ INSTALLED_APPS = [
     'main',
     # API serializer
     'rest_framework',
+    #App that handle the traffic_api
+    'traffic_api',
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
Adding "traffic_api" to the "INSTALLED_APPS" list, Django will recognize the app and include it in the project.