### PR TITLE
Add traffic_api url paths in urls.py top folder

### DIFF
--- a/daelibs_interview/urls.py
+++ b/daelibs_interview/urls.py
@@ -15,8 +15,13 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 
 urlpatterns = [
+    # Include the app's URLs from the 'traffic_api' app
+    # This line includes the URL patterns defined in 'traffic_api.urls' into the project
+    # The first argument is an empty string, meaning that these URLs will be included at the root level of the project
+    # The 'include' function is used to include the URLs from 'traffic_api.urls' module
+    path('', include('traffic_api.urls')),
     path('admin/', admin.site.urls),
 ]


### PR DESCRIPTION
Added the URL patterns for the 'traffic_api' app in the top-level 'urls.py' file. The 'include' function is used to include the URL patterns defined in 'traffic_api.urls' into the project. The first argument for 'include' is an empty string, meaning that these URLs will be included at the root level of the project. This makes the 'day_of_week_average_count' API view accessible at the URL '/traffic/dayOfWeekAverageCount/'. Clients can make GET requests with 'start_date' and 'end_date' query parameters in the URL to retrieve the day of week average count data for the specified date range.